### PR TITLE
Add bottom navigation bar

### DIFF
--- a/MainTabView.swift
+++ b/MainTabView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            NavigationView {
+                LocationSelectionView()
+            }
+            .tabItem {
+                Image(systemName: "house")
+                Text("Home")
+            }
+
+            NavigationView {
+                ProfileView()
+            }
+            .tabItem {
+                Image(systemName: "person")
+                Text("Profile")
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct MainTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabView().environmentObject(AuthViewModel())
+    }
+}
+#endif

--- a/ProfileView.swift
+++ b/ProfileView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject private var authVM: AuthViewModel
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let email = authVM.user?.email {
+                Text(email)
+                    .font(.headline)
+            }
+            Button("Sign Out") {
+                authVM.signOut()
+            }
+            .padding()
+            Spacer()
+        }
+        .navigationTitle("Profile")
+    }
+}
+
+#if DEBUG
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView().environmentObject(AuthViewModel())
+    }
+}
+#endif

--- a/YukiApp.swift
+++ b/YukiApp.swift
@@ -13,7 +13,7 @@ struct YukiAppApp: App {
                 } else if authVM.role == "artist" {
                     DashboardView().environmentObject(authVM)
                 } else if authVM.role == "user" {
-                    LocationSelectionView().environmentObject(authVM)
+                    MainTabView().environmentObject(authVM)
                 } else {
                     ProgressView()
                 }


### PR DESCRIPTION
## Summary
- build a simple profile page to sign out
- create a tab view with Home and Profile icons
- show the new tab view for regular users

## Testing
- `swift --version`
- `swiftc -o testbuild ...` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68837c703750832893ac5a03ebdda0a2