### PR TITLE
Update auth flow with name and phone

### DIFF
--- a/AuthViewModel.swift
+++ b/AuthViewModel.swift
@@ -38,14 +38,18 @@ final class AuthViewModel: ObservableObject {
         isLoading = false
     }
 
-    func register(email: String, password: String) async {
+    func register(name: String, phone: String, email: String, password: String, confirmPassword: String) async {
+        guard password == confirmPassword else {
+            self.error = "Passwords do not match"
+            return
+        }
         isLoading = true
         error = nil
         do {
             let result = try await Auth.auth().createUser(withEmail: email, password: password)
             self.user = result.user
             let ref = Database.database().reference().child("users").child(result.user.uid)
-            try await ref.setValue(["role": "user"])
+            try await ref.setValue(["role": "user", "name": name, "phone": phone])
             await fetchUserRole()
         } catch {
             self.error = error.localizedDescription

--- a/EmailAuthView.swift
+++ b/EmailAuthView.swift
@@ -4,15 +4,28 @@ struct EmailAuthView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @State private var email = ""
     @State private var password = ""
+    @State private var confirmPassword = ""
+    @State private var name = ""
+    @State private var phone = ""
 
     var body: some View {
         VStack(spacing: 16) {
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Phone", text: $phone)
+                .keyboardType(.phonePad)
+                .textFieldStyle(.roundedBorder)
+
             TextField("Email", text: $email)
                 .keyboardType(.emailAddress)
                 .autocapitalization(.none)
                 .textFieldStyle(.roundedBorder)
 
             SecureField("Password (min 6 chars)", text: $password)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField("Confirm Password", text: $confirmPassword)
                 .textFieldStyle(.roundedBorder)
 
             if let error = authVM.error, !error.isEmpty {
@@ -27,7 +40,9 @@ struct EmailAuthView: View {
             .disabled(authVM.isLoading)
 
             Button("Register") {
-                Task { await authVM.register(email: email, password: password) }
+                Task {
+                    await authVM.register(name: name, phone: phone, email: email, password: password, confirmPassword: confirmPassword)
+                }
             }
             .buttonStyle(.bordered)
             .disabled(authVM.isLoading)


### PR DESCRIPTION
## Summary
- extend registration to collect name and phone number
- require password confirmation during registration
- store the extra information in Firebase

## Testing
- `swift -version`


------
https://chatgpt.com/codex/tasks/task_e_68837d2bee44832895d6bed324973fa1