### PR TITLE
Implement first-launch registration flow

### DIFF
--- a/LoginView.swift
+++ b/LoginView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject private var authVM: AuthViewModel
+    @State private var email = ""
+    @State private var password = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            TextField("Email", text: $email)
+                .keyboardType(.emailAddress)
+                .autocapitalization(.none)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+
+            if let error = authVM.error, !error.isEmpty {
+                Text(error)
+                    .foregroundColor(.red)
+            }
+
+            Button("Log In") {
+                Task { await authVM.login(email: email, password: password) }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(authVM.isLoading)
+
+            if authVM.isLoading { ProgressView() }
+        }
+        .padding()
+    }
+}
+

--- a/RegisterView.swift
+++ b/RegisterView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct RegisterView: View {
+    @EnvironmentObject private var authVM: AuthViewModel
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirmPassword = ""
+    @State private var name = ""
+    @State private var phone = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            TextField("Name", text: $name)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Phone", text: $phone)
+                .keyboardType(.phonePad)
+                .textFieldStyle(.roundedBorder)
+
+            TextField("Email", text: $email)
+                .keyboardType(.emailAddress)
+                .autocapitalization(.none)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField("Password (min 6 chars)", text: $password)
+                .textFieldStyle(.roundedBorder)
+
+            SecureField("Confirm Password", text: $confirmPassword)
+                .textFieldStyle(.roundedBorder)
+
+            if let error = authVM.error, !error.isEmpty {
+                Text(error)
+                    .foregroundColor(.red)
+            }
+
+            Button("Register") {
+                Task {
+                    await authVM.register(name: name, phone: phone, email: email, password: password, confirmPassword: confirmPassword)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(authVM.isLoading)
+
+            if authVM.isLoading { ProgressView() }
+        }
+        .padding()
+        .onAppear {
+            UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+        }
+    }
+}
+

--- a/YukiApp.swift
+++ b/YukiApp.swift
@@ -4,12 +4,17 @@ import SwiftUI
 struct YukiAppApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @StateObject private var authVM = AuthViewModel()
+    @AppStorage("hasLaunchedBefore") private var hasLaunchedBefore = false
 
     var body: some Scene {
         WindowGroup {
             Group {
                 if authVM.user == nil {
-                    EmailAuthView().environmentObject(authVM)
+                    if hasLaunchedBefore {
+                        LoginView().environmentObject(authVM)
+                    } else {
+                        RegisterView().environmentObject(authVM)
+                    }
                 } else if authVM.role == "artist" {
                     DashboardView().environmentObject(authVM)
                 } else if authVM.role == "user" {


### PR DESCRIPTION
## Summary
- add distinct Login and Register screens
- display Register view on first launch and Login view afterwards

## Testing
- `swiftc -typecheck YukiApp.swift` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68837f20b83c8328be951235850ef3a3