### PR TITLE
Add registration and password reset to login view

### DIFF
--- a/AuthViewModel.swift
+++ b/AuthViewModel.swift
@@ -57,6 +57,17 @@ final class AuthViewModel: ObservableObject {
         isLoading = false
     }
 
+    func resetPassword(email: String) async {
+        isLoading = true
+        error = nil
+        do {
+            try await Auth.auth().sendPasswordReset(withEmail: email)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
     func signOut() {
         do {
             try Auth.auth().signOut()

--- a/LoginView.swift
+++ b/LoginView.swift
@@ -4,6 +4,9 @@ struct LoginView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @State private var email = ""
     @State private var password = ""
+    @State private var showRegister = false
+    @State private var showResetAlert = false
+    @State private var resetMessage = ""
 
     var body: some View {
         VStack(spacing: 16) {
@@ -20,15 +23,36 @@ struct LoginView: View {
                     .foregroundColor(.red)
             }
 
-            Button("Log In") {
-                Task { await authVM.login(email: email, password: password) }
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(authVM.isLoading)
+        Button("Log In") {
+            Task { await authVM.login(email: email, password: password) }
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(authVM.isLoading)
 
-            if authVM.isLoading { ProgressView() }
+        Button("Forgot Password?") {
+            Task {
+                await authVM.resetPassword(email: email)
+                resetMessage = "If an account exists, a reset email has been sent."
+                showResetAlert = true
+            }
+        }
+        .font(.footnote)
+        .padding(.top, -8)
+
+        Button("Register") {
+            showRegister = true
+        }
+        .buttonStyle(.bordered)
+        .sheet(isPresented: $showRegister) {
+            RegisterView().environmentObject(authVM)
+        }
+
+        if authVM.isLoading { ProgressView() }
         }
         .padding()
+        .alert(resetMessage, isPresented: $showResetAlert) {
+            Button("OK", role: .cancel) { }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- improve `LoginView` with actions to register and reset passwords
- implement `resetPassword` method in the auth view model

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_688380c259f0832887767958f440ac6f