### PR TITLE
Admin dashboard with booking management

### DIFF
--- a/Booking.swift
+++ b/Booking.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Represents a single booking made by a user.
+struct Booking: Identifiable {
+    /// Unique Firestore document id
+    let id: String
+    /// UID of the user who created the booking
+    let userId: String
+    /// The artist identifier
+    let artistId: Int
+    /// Time in HH:mm format
+    let time: String
+    /// Current status: pending/accepted/canceled
+    var status: String
+}

--- a/BookingViewModel.swift
+++ b/BookingViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+import FirebaseFirestore
+
+@MainActor
+final class BookingViewModel: ObservableObject {
+    @Published var bookings: [Booking] = []
+    @Published var error: String?
+
+    private let db = Firestore.firestore()
+
+    /// Fetch all bookings for admin dashboard
+    func fetchBookings() async {
+        do {
+            let snapshot = try await db.collection("bookings").getDocuments()
+            let docs = snapshot.documents
+            self.bookings = docs.map { doc in
+                let data = doc.data()
+                return Booking(
+                    id: doc.documentID,
+                    userId: data["userId"] as? String ?? "",
+                    artistId: data["artistId"] as? Int ?? 0,
+                    time: data["time"] as? String ?? "",
+                    status: data["status"] as? String ?? "pending"
+                )
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Update the status of a booking document
+    func updateBooking(_ booking: Booking, to status: String) async {
+        do {
+            try await db.collection("bookings").document(booking.id).updateData(["status": status])
+            if let index = bookings.firstIndex(where: { $0.id == booking.id }) {
+                bookings[index].status = status
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/DashboardView.swift
+++ b/DashboardView.swift
@@ -1,16 +1,39 @@
 import SwiftUI
 
+/// Dashboard shown for admin users to manage bookings.
 struct DashboardView: View {
     @EnvironmentObject private var authVM: AuthViewModel
+    @StateObject private var bookingVM = BookingViewModel()
 
     var body: some View {
-        VStack {
-            Text("Artist Dashboard")
-                .font(.title)
-            Button("Sign Out") {
-                authVM.signOut()
+        NavigationView {
+            List {
+                ForEach(bookingVM.bookings) { booking in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("User: \(booking.userId)")
+                        Text("Time: \(booking.time)")
+                        Text("Status: \(booking.status)")
+                        HStack {
+                            Button("Accept") {
+                                Task { await bookingVM.updateBooking(booking, to: "accepted") }
+                            }
+                            .disabled(booking.status == "accepted")
+
+                            Button("Cancel") {
+                                Task { await bookingVM.updateBooking(booking, to: "canceled") }
+                            }
+                            .tint(.red)
+                            .disabled(booking.status == "canceled")
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
             }
-            .padding()
+            .navigationTitle("Dashboard")
+            .toolbar {
+                Button("Sign Out") { authVM.signOut() }
+            }
+            .task { await bookingVM.fetchBookings() }
         }
     }
 }

--- a/YukiApp.swift
+++ b/YukiApp.swift
@@ -15,7 +15,7 @@ struct YukiAppApp: App {
                     } else {
                         RegisterView().environmentObject(authVM)
                     }
-                } else if authVM.role == "artist" {
+                } else if authVM.role == "admin" {
                     DashboardView().environmentObject(authVM)
                 } else if authVM.role == "user" {
                     MainTabView().environmentObject(authVM)


### PR DESCRIPTION
## Summary
- add `Booking` model and `BookingViewModel` to manage bookings in Firestore
- extend `TimeSelectionView` to save bookings
- create a functional `DashboardView` for admins to accept or cancel bookings
- update app launch flow to show dashboard when role is `admin`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_688381b4be6483288df7ac0eb0e16afb