### PR TITLE
Fix Firebase error handling in AuthViewModel

### DIFF
--- a/AuthViewModel.swift
+++ b/AuthViewModel.swift
@@ -16,7 +16,8 @@ final class AuthViewModel: ObservableObject {
 
     /// Maps Firebase errors to user friendly messages
     private func handleAuthError(_ error: Error) {
-        if let code = AuthErrorCode.Code(rawValue: (error as NSError).code) {
+        // Convert NSError code into Firebase's AuthErrorCode enumeration
+        if let code = AuthErrorCode(rawValue: (error as NSError).code) {
             switch code {
             case .invalidEmail:
                 self.error = "Invalid email address"


### PR DESCRIPTION
## Summary
- use `AuthErrorCode` directly instead of the non-existent `AuthErrorCode.Code`
- add comment clarifying conversion of `NSError` to `AuthErrorCode`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688388d6c0708328865c7c8f12e1799a