### PR TITLE
Remove invalid accentColor call

### DIFF
--- a/YukiApp.swift
+++ b/YukiApp.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+/// Entry point of the application.
+/// Uses the MVVM architecture by injecting the ``AuthViewModel``
+/// into the environment for all child views.
+
 @main
 struct YukiAppApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
@@ -25,6 +29,5 @@ struct YukiAppApp: App {
             }
             .tint(Color("AccentColor"))
         }
-        .accentColor(Color("AccentColor"))
     }
 }


### PR DESCRIPTION
## Summary
- remove accentColor modifier from the `WindowGroup`
- document MVVM usage in `YukiApp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688389ca3d0083289471243d38c8446e