### PR TITLE
Improve Firebase error handling

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -1,10 +1,15 @@
 import UIKit
 import FirebaseCore
+import FirebaseDatabase
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         FirebaseApp.configure()
+        // Enable offline persistence so queries can be served from cache when
+        // the device is offline. This helps avoid "client offline" errors when
+        // there are no active listeners.
+        Database.database().isPersistenceEnabled = true
         return true
     }
 }

--- a/BookingViewModel.swift
+++ b/BookingViewModel.swift
@@ -27,7 +27,13 @@ final class BookingViewModel: ObservableObject {
             }
             self.bookings = loaded
         } catch {
-            self.error = error.localizedDescription
+            if let dbError = error as NSError?,
+               dbError.domain == DatabaseErrorDomain,
+               DatabaseErrorCode(rawValue: dbError.code) == .networkError {
+                self.error = "Unable to fetch bookings. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
         }
     }
 
@@ -40,7 +46,13 @@ final class BookingViewModel: ObservableObject {
                 bookings[index].status = status
             }
         } catch {
-            self.error = error.localizedDescription
+            if let dbError = error as NSError?,
+               dbError.domain == DatabaseErrorDomain,
+               DatabaseErrorCode(rawValue: dbError.code) == .networkError {
+                self.error = "Unable to update booking. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
         }
     }
 }

--- a/TimeSelectionViewModel.swift
+++ b/TimeSelectionViewModel.swift
@@ -34,7 +34,15 @@ final class TimeSelectionViewModel: ObservableObject {
             } ?? []
             reservedSlots = Set(hours)
         } catch {
-            self.error = error.localizedDescription
+            // Cast to Firebase's ``DatabaseError`` to check for connectivity
+            // issues and provide a more user friendly message.
+            if let dbError = error as NSError?,
+               dbError.domain == DatabaseErrorDomain,
+               DatabaseErrorCode(rawValue: dbError.code) == .networkError {
+                self.error = "Unable to fetch slots. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
         }
     }
 
@@ -61,7 +69,14 @@ final class TimeSelectionViewModel: ObservableObject {
             bookingSuccess = true
             await fetchReservedSlots(for: artistId)
         } catch {
-            self.error = error.localizedDescription
+            // Surface network connectivity issues to the view.
+            if let dbError = error as NSError?,
+               dbError.domain == DatabaseErrorDomain,
+               DatabaseErrorCode(rawValue: dbError.code) == .networkError {
+                self.error = "Unable to create booking. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
         }
         isCreating = false
     }


### PR DESCRIPTION
## Summary
- enable Firebase offline caching in the app delegate
- surface connection errors when fetching/updating bookings
- improve booking creation error messages

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68838c72c9a88328a032096c3565ab7f