### PR TITLE
Add admin dashboard and dynamic artists

### DIFF
--- a/AdminTabView.swift
+++ b/AdminTabView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Tab bar displayed for admin users.
+struct AdminTabView: View {
+    var body: some View {
+        TabView {
+            NavigationView {
+                DashboardView()
+            }
+            .tabItem {
+                Image(systemName: "house")
+                Text("Home")
+            }
+
+            NavigationView {
+                ArtistManagementView()
+            }
+            .tabItem {
+                Image(systemName: "person.3")
+                Text("Artists")
+            }
+
+            NavigationView {
+                FinanceView()
+            }
+            .tabItem {
+                Image(systemName: "creditcard")
+                Text("Finance")
+            }
+        }
+    }
+}

--- a/Artist.swift
+++ b/Artist.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Represents an artist account promoted by an admin.
+struct Artist: Identifiable {
+    /// Firebase UID of the artist user
+    let id: String
+    /// Display name of the artist
+    let name: String
+}

--- a/ArtistDashboardView.swift
+++ b/ArtistDashboardView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Dashboard shown to artists for managing their own bookings.
+struct ArtistDashboardView: View {
+    @EnvironmentObject private var authVM: AuthViewModel
+    @StateObject private var bookingVM = BookingViewModel()
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(bookingVM.bookings) { booking in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("User: \(booking.userId)")
+                        Text("Time: \(booking.time)")
+                        Text("Status: \(booking.status)")
+                        HStack {
+                            Button("Accept") {
+                                Task {
+                                    await bookingVM.updateBooking(booking, to: "accepted")
+                                    await bookingVM.fetchBookings(artistId: authVM.user?.uid)
+                                }
+                            }
+                            .disabled(booking.status == "accepted")
+
+                            Button("Cancel") {
+                                Task {
+                                    await bookingVM.updateBooking(booking, to: "canceled")
+                                    await bookingVM.fetchBookings(artistId: authVM.user?.uid)
+                                }
+                            }
+                            .tint(.red)
+                            .disabled(booking.status == "canceled")
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("My Bookings")
+            .toolbar {
+                Button("Sign Out") { authVM.signOut() }
+            }
+            .task {
+                await bookingVM.fetchBookings(artistId: authVM.user?.uid)
+            }
+        }
+    }
+}

--- a/ArtistManagementView.swift
+++ b/ArtistManagementView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// View for admins to manage artists.
+struct ArtistManagementView: View {
+    @StateObject private var viewModel = ArtistViewModel()
+    @State private var email = ""
+
+    var body: some View {
+        VStack {
+            List {
+                Section(header: Text("Artists")) {
+                    ForEach(viewModel.artists) { artist in
+                        HStack {
+                            Text(artist.name)
+                            Spacer()
+                            Button(role: .destructive) {
+                                Task { await viewModel.removeArtist(artist) }
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                        }
+                    }
+                }
+
+                Section(header: Text("Add Artist")) {
+                    TextField("User email", text: $email)
+                        .keyboardType(.emailAddress)
+                        .autocapitalization(.none)
+                    Button("Add") {
+                        Task {
+                            await viewModel.addArtist(email: email)
+                            email = ""
+                        }
+                    }
+                }
+            }
+            if let error = viewModel.error {
+                Text(error)
+                    .foregroundColor(.red)
+                    .padding()
+            }
+        }
+        .navigationTitle("Artists")
+        .task { await viewModel.fetchArtists() }
+    }
+}

--- a/ArtistSelectionView.swift
+++ b/ArtistSelectionView.swift
@@ -1,20 +1,11 @@
 import SwiftUI
 
-struct Artist: Identifiable {
-    let id: Int
-    let name: String
-}
 
 struct ArtistSelectionView: View {
     var selectedLocation: Location?
     @State private var selectedArtist: Artist?
     @State private var showBooking = false
-
-    private let artists = [
-        Artist(id: 1, name: "Ари"),
-        Artist(id: 2, name: "Зулаа"),
-        Artist(id: 3, name: "Болормаа")
-    ]
+    @StateObject private var viewModel = ArtistViewModel()
 
     var body: some View {
         NavigationView {
@@ -23,7 +14,7 @@ struct ArtistSelectionView: View {
                     .font(.system(size: 22, weight: .bold))
                     .padding(.top, 32)
 
-                ForEach(artists) { artist in
+                ForEach(viewModel.artists) { artist in
                     Button(action: { selectedArtist = artist }) {
                         HStack {
                             Text(artist.name)
@@ -64,6 +55,7 @@ struct ArtistSelectionView: View {
                     TimeSelectionView(selectedArtist: artist.id)
                 }
             }
+            .task { await viewModel.fetchArtists() }
             .navigationTitle("Artist сонгох")
             .navigationBarTitleDisplayMode(.inline)
         }

--- a/ArtistViewModel.swift
+++ b/ArtistViewModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+import FirebaseDatabase
+
+@MainActor
+final class ArtistViewModel: ObservableObject {
+    @Published var artists: [Artist] = []
+    @Published var error: String?
+
+    private let db = Database.database().reference()
+
+    /// Fetch all artists available for bookings
+    func fetchArtists() async {
+        error = nil
+        do {
+            let snapshot = try await db.child("artists").getData()
+            var loaded: [Artist] = []
+            for child in snapshot.children.allObjects as? [DataSnapshot] ?? [] {
+                if let value = child.value as? [String: Any] {
+                    let name = value["name"] as? String ?? ""
+                    loaded.append(Artist(id: child.key, name: name))
+                }
+            }
+            artists = loaded
+        } catch {
+            if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
+                self.error = "Unable to fetch artists. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+
+    /// Promote an existing user to artist role using their email.
+    func addArtist(email: String) async {
+        guard !email.isEmpty else {
+            self.error = "Email is required"
+            return
+        }
+        error = nil
+        do {
+            let usersSnap = try await db.child("users").getData()
+            guard let users = usersSnap.children.allObjects as? [DataSnapshot] else {
+                self.error = "User not found"
+                return
+            }
+            for userSnap in users {
+                if let data = userSnap.value as? [String: Any],
+                   let emailValue = data["email"] as? String,
+                   emailValue.lowercased() == email.lowercased() {
+                    let name = data["name"] as? String ?? ""
+                    try await db.child("users").child(userSnap.key).child("role").setValue("artist")
+                    try await db.child("artists").child(userSnap.key).setValue(["name": name])
+                    await fetchArtists()
+                    return
+                }
+            }
+            self.error = "User not found"
+        } catch {
+            if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
+                self.error = "Unable to add artist. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+
+    /// Remove artist privileges from a user.
+    func removeArtist(_ artist: Artist) async {
+        error = nil
+        do {
+            try await db.child("artists").child(artist.id).removeValue()
+            try await db.child("users").child(artist.id).child("role").setValue("user")
+            await fetchArtists()
+        } catch {
+            if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
+                self.error = "Unable to remove artist. Check your internet connection."
+            } else {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+}

--- a/AuthViewModel.swift
+++ b/AuthViewModel.swift
@@ -92,7 +92,7 @@ final class AuthViewModel: ObservableObject {
             let result = try await Auth.auth().createUser(withEmail: email, password: password)
             self.user = result.user
             let ref = Database.database().reference().child("users").child(result.user.uid)
-            try await ref.setValue(["role": "user", "name": name, "phone": phone])
+            try await ref.setValue(["role": "user", "name": name, "phone": phone, "email": email])
             await fetchUserRole()
         } catch {
             handleAuthError(error)

--- a/Booking.swift
+++ b/Booking.swift
@@ -6,8 +6,8 @@ struct Booking: Identifiable {
     let id: String
     /// UID of the user who created the booking
     let userId: String
-    /// The artist identifier
-    let artistId: Int
+    /// The artist identifier (Firebase UID)
+    let artistId: String
     /// Time in HH:mm format
     let time: String
     /// Current status: pending/accepted/canceled

--- a/FinanceView.swift
+++ b/FinanceView.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+/// Placeholder view representing financial information for admins.
+struct FinanceView: View {
+    var body: some View {
+        Text("Finance Dashboard")
+            .font(.headline)
+            .navigationTitle("Finance")
+    }
+}

--- a/TimeSelectionView.swift
+++ b/TimeSelectionView.swift
@@ -6,7 +6,7 @@ struct TimeSlot: Identifiable {
 }
 
 struct TimeSelectionView: View {
-    var selectedArtist: Int
+    var selectedArtist: String
     @State private var selectedSlot: Int?
     @StateObject private var viewModel = TimeSelectionViewModel()
 

--- a/TimeSelectionViewModel.swift
+++ b/TimeSelectionViewModel.swift
@@ -17,7 +17,7 @@ final class TimeSelectionViewModel: ObservableObject {
 
     /// Fetch all accepted bookings for the provided artist.
     /// - Parameter artistId: Identifier of the artist to filter bookings.
-    func fetchReservedSlots(for artistId: Int) async {
+    func fetchReservedSlots(for artistId: String) async {
         error = nil
         do {
             let snapshot = try await db.child("bookings")
@@ -48,7 +48,7 @@ final class TimeSelectionViewModel: ObservableObject {
     /// - Parameters:
     ///   - artistId: The selected artist identifier.
     ///   - slot: Hour value for the booking.
-    func createBooking(for artistId: Int, slot: Int) async {
+    func createBooking(for artistId: String, slot: Int) async {
         guard let uid = Auth.auth().currentUser?.uid else {
             error = "User not logged in"
             return

--- a/YukiApp.swift
+++ b/YukiApp.swift
@@ -20,7 +20,9 @@ struct YukiAppApp: App {
                         RegisterView().environmentObject(authVM)
                     }
                 } else if authVM.role == "admin" {
-                    DashboardView().environmentObject(authVM)
+                    AdminTabView().environmentObject(authVM)
+                } else if authVM.role == "artist" {
+                    ArtistDashboardView().environmentObject(authVM)
                 } else if authVM.role == "user" {
                     MainTabView().environmentObject(authVM)
                 } else {


### PR DESCRIPTION
## Summary
- implement admin bottom bar via `AdminTabView`
- enable admin to add or remove artists with `ArtistManagementView`
- fetch artists dynamically using new `ArtistViewModel`
- add artist dashboard to manage bookings
- switch views in `YukiApp` based on new `artist` role
- store email on registration for role promotion
- update booking logic to use artist UID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688393e0533083288fb1246b64497a43