### PR TITLE
Add branch assignment and booking ordering features

### DIFF
--- a/ArtistDashboardView.swift
+++ b/ArtistDashboardView.swift
@@ -5,6 +5,14 @@ struct ArtistDashboardView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @StateObject private var bookingVM = BookingViewModel()
 
+    private func formattedDate(_ timestamp: TimeInterval) -> String {
+        let date = Date(timeIntervalSince1970: timestamp)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
     var body: some View {
         NavigationView {
             List {
@@ -12,6 +20,7 @@ struct ArtistDashboardView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("User: \(booking.userId)")
                         Text("Time: \(booking.time)")
+                        Text("Booked: \(formattedDate(booking.createdAt))")
                         Text("Status: \(booking.status)")
                         HStack {
                             Button("Accept") {

--- a/ArtistManagementView.swift
+++ b/ArtistManagementView.swift
@@ -5,6 +5,10 @@ struct ArtistManagementView: View {
     @StateObject private var viewModel = ArtistViewModel()
     @State private var email = ""
 
+    private func locationName(for id: Int) -> String {
+        locations.first(where: { $0.id == id })?.name ?? String(id)
+    }
+
     var body: some View {
         VStack {
             List {
@@ -14,12 +18,21 @@ struct ArtistManagementView: View {
                             VStack(alignment: .leading) {
                                 Text(artist.name)
                                 if let location = artist.locationId {
-                                    Text("Location: \(location)")
+                                    Text("Location: \(locationName(for: location))")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
                             }
                             Spacer()
+                            Menu {
+                                ForEach(locations) { location in
+                                    Button(location.name) {
+                                        Task { await viewModel.assignArtist(artist.id, to: location.id) }
+                                    }
+                                }
+                            } label: {
+                                Image(systemName: "mappin.and.ellipse")
+                            }
                             Button(role: .destructive) {
                                 Task { await viewModel.removeArtist(artist) }
                             } label: {

--- a/Booking.swift
+++ b/Booking.swift
@@ -10,6 +10,8 @@ struct Booking: Identifiable {
     let artistId: String
     /// Time in HH:mm format
     let time: String
+    /// Timestamp when the booking was created
+    let createdAt: TimeInterval
     /// Current status: pending/accepted/canceled
     var status: String
 }

--- a/BookingViewModel.swift
+++ b/BookingViewModel.swift
@@ -36,11 +36,12 @@ final class BookingViewModel: ObservableObject {
                     userId: value["userId"] as? String ?? "",
                     artistId: value["artistId"] as? String ?? "",
                     time: value["time"] as? String ?? "",
+                    createdAt: value["createdAt"] as? TimeInterval ?? 0,
                     status: value["status"] as? String ?? "pending"
                 )
                 loaded.append(booking)
             }
-            self.bookings = loaded
+            self.bookings = loaded.sorted { $0.createdAt > $1.createdAt }
         } catch {
             // Attempt to surface a more friendly message when the
             // device has no internet connectivity. Firebase currently

--- a/BranchArtistsView.swift
+++ b/BranchArtistsView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Displays artists assigned to a particular branch along with their bookings.
+struct BranchArtistsView: View {
+    let location: Location
+    @StateObject private var artistVM = ArtistViewModel()
+    @StateObject private var bookingVM = BookingViewModel()
+    @State private var selectedArtist: Artist?
+    @State private var showingTimeSelection = false
+
+    private func bookings(for artist: Artist) -> [Booking] {
+        bookingVM.bookings.filter { $0.artistId == artist.id }
+    }
+
+    private func formattedDate(_ timestamp: TimeInterval) -> String {
+        let date = Date(timeIntervalSince1970: timestamp)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    var body: some View {
+        List {
+            ForEach(artistVM.artists.filter { $0.locationId == location.id }) { artist in
+                Section(header: Text(artist.name)) {
+                    ForEach(bookings(for: artist)) { booking in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Time: \(booking.time)")
+                            Text("Booked: \(formattedDate(booking.createdAt))")
+                            Text("Status: \(booking.status)")
+                        }
+                    }
+                    Button("Book time") {
+                        selectedArtist = artist
+                        showingTimeSelection = true
+                    }
+                }
+            }
+        }
+        .navigationTitle(location.name)
+        .sheet(isPresented: $showingTimeSelection) {
+            if let artist = selectedArtist {
+                TimeSelectionView(selectedArtist: artist.id)
+            }
+        }
+        .task {
+            await artistVM.fetchArtists()
+            await bookingVM.fetchBookings()
+        }
+    }
+}

--- a/DashboardView.swift
+++ b/DashboardView.swift
@@ -5,6 +5,14 @@ struct DashboardView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @StateObject private var bookingVM = BookingViewModel()
 
+    private func formattedDate(_ timestamp: TimeInterval) -> String {
+        let date = Date(timeIntervalSince1970: timestamp)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
     var body: some View {
         NavigationView {
             List {
@@ -12,6 +20,7 @@ struct DashboardView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("User: \(booking.userId)")
                         Text("Time: \(booking.time)")
+                        Text("Booked: \(formattedDate(booking.createdAt))")
                         Text("Status: \(booking.status)")
                         HStack {
                             Button("Accept") {

--- a/Location.swift
+++ b/Location.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Represents a salon branch/location.
+struct Location: Identifiable {
+    /// Unique numeric identifier used in the database
+    let id: Int
+    /// Display name for the location
+    let name: String
+}
+
+/// Predefined list of all available locations used across the app.
+let locations: [Location] = [
+    Location(id: 1, name: "Их дэлгүүрийн баруун талд"),
+    Location(id: 2, name: "Чингис зочид буудал"),
+    Location(id: 3, name: "Санто Апартмент"),
+    Location(id: 4, name: "VIP Center")
+]

--- a/LocationSelectionView.swift
+++ b/LocationSelectionView.swift
@@ -1,21 +1,10 @@
 import SwiftUI
 
-struct Location: Identifiable {
-    let id: Int
-    let name: String
-}
-
 struct LocationSelectionView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @State private var selectedLocation: Location?
     @State private var isChoosingArtist = false
 
-    private let locations = [
-        Location(id: 1, name: "Их дэлгүүрийн баруун талд"),
-        Location(id: 2, name: "Чингис зочид буудал"),
-        Location(id: 3, name: "Санто Апартмент"),
-        Location(id: 4, name: "VIP Center")
-    ]
 
     var body: some View {
         VStack(spacing: 24) {
@@ -59,9 +48,19 @@ struct LocationSelectionView: View {
             .padding(.bottom, 24)
         }
         .padding(.horizontal, 16)
-        .sheet(isPresented: $isChoosingArtist) {
-            ArtistSelectionView(selectedLocation: selectedLocation)
-        }
+        .background(
+            NavigationLink(
+                destination: Group {
+                    if let location = selectedLocation {
+                        BranchArtistsView(location: location)
+                    }
+                },
+                isActive: $isChoosingArtist
+            ) {
+                EmptyView()
+            }
+            .hidden()
+        )
         .navigationTitle("Locations")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ProfileView.swift
+++ b/ProfileView.swift
@@ -5,6 +5,14 @@ struct ProfileView: View {
     @StateObject private var bookingVM = BookingViewModel()
     @StateObject private var artistVM = ArtistViewModel()
 
+    private func formattedDate(_ timestamp: TimeInterval) -> String {
+        let date = Date(timeIntervalSince1970: timestamp)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
     private func artistName(for id: String) -> String {
         artistVM.artists.first(where: { $0.id == id })?.name ?? id
     }
@@ -24,6 +32,7 @@ struct ProfileView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Artist: \(artistName(for: booking.artistId))")
                         Text("Time: \(booking.time)")
+                        Text("Booked: \(formattedDate(booking.createdAt))")
                         Text("Status: \(booking.status)")
                     }
                 }

--- a/TimeSelectionViewModel.swift
+++ b/TimeSelectionViewModel.swift
@@ -59,7 +59,8 @@ final class TimeSelectionViewModel: ObservableObject {
             "userId": uid,
             "artistId": artistId,
             "time": String(format: "%02d:00", slot),
-            "status": "pending"
+            "status": "pending",
+            "createdAt": Date().timeIntervalSince1970
         ]
         do {
             let ref = db.child("bookings").childByAutoId()


### PR DESCRIPTION
## Summary
- allow admins to assign artists to locations
- centralize location definitions
- show artists and their bookings for a branch
- record booking creation time and order bookings by newest first
- display creation dates in dashboards and profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839cc96abc8328be2fbd2a8c4f0c17