### PR TITLE
Improve time booking flow

### DIFF
--- a/ArtistSelectionView.swift
+++ b/ArtistSelectionView.swift
@@ -20,7 +20,10 @@ struct ArtistSelectionView: View {
                     }
                     return true
                 }) { artist in
-                    Button(action: { selectedArtist = artist }) {
+                    Button(action: {
+                        selectedArtist = artist
+                        showBooking = true
+                    }) {
                         HStack {
                             Text(artist.name)
                                 .font(.system(size: 16, weight: .semibold))
@@ -42,17 +45,6 @@ struct ArtistSelectionView: View {
                 }
 
                 Spacer()
-
-                if selectedArtist != nil {
-                    Button(action: { showBooking = true }) {
-                        Text("Цаг авах")
-                            .font(.system(size: 16, weight: .semibold))
-                            .frame(maxWidth: .infinity, minHeight: 50)
-                    }
-                    .background(Color("AccentColor"))
-                    .foregroundColor(.white)
-                    .cornerRadius(12)
-                }
             }
             .padding(.horizontal, 16)
             .sheet(isPresented: $showBooking) {

--- a/TimeSelectionView.swift
+++ b/TimeSelectionView.swift
@@ -16,7 +16,8 @@ struct TimeSelectionView: View {
     @EnvironmentObject private var router: TabRouter
     @Environment(\.presentationMode) private var presentationMode
 
-    let timeSlots: [TimeSlot] = (9...18).map { hour in
+    /// Available booking slots from 9 AM to 11 PM.
+    let timeSlots: [TimeSlot] = (9...23).map { hour in
         TimeSlot(id: hour, time: String(format: "%02d:00", hour))
     }
 


### PR DESCRIPTION
## Summary
- launch booking immediately when selecting an artist
- extend available booking hours up to 11pm

## Testing
- `swift --version`
- `swiftc -parse-as-library ArtistSelectionView.swift TimeSelectionView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6883abf9720c8328baa1434b0c531e86