### PR TITLE
Update booking time range

### DIFF
--- a/TimeSelectionView.swift
+++ b/TimeSelectionView.swift
@@ -16,8 +16,8 @@ struct TimeSelectionView: View {
     @EnvironmentObject private var router: TabRouter
     @Environment(\.presentationMode) private var presentationMode
 
-    /// Available booking slots from 9 AM to 11 PM.
-    let timeSlots: [TimeSlot] = (9...23).map { hour in
+    /// Available booking slots from 9 AM to 6 PM.
+    let timeSlots: [TimeSlot] = (9...18).map { hour in
         TimeSlot(id: hour, time: String(format: "%02d:00", hour))
     }
 


### PR DESCRIPTION
## Summary
- limit available booking hours to 9 AM–6 PM

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883ae35eab083288a8036027d01dab2