### PR TITLE
Improve booking status visualization

### DIFF
--- a/ArtistDashboardView.swift
+++ b/ArtistDashboardView.swift
@@ -13,6 +13,18 @@ struct ArtistDashboardView: View {
         return formatter.string(from: date)
     }
 
+    /// Maps booking status to a color used as row background.
+    private func statusColor(for status: String) -> Color {
+        switch status {
+        case "accepted":
+            return Color.green.opacity(0.2)
+        case "canceled":
+            return Color.red.opacity(0.2)
+        default:
+            return Color.orange.opacity(0.2)
+        }
+    }
+
     var body: some View {
         NavigationView {
             List {
@@ -23,6 +35,7 @@ struct ArtistDashboardView: View {
                         Text("Time: \(booking.time)")
                         Text("Booked: \(formattedDate(booking.createdAt))")
                         Text("Status: \(booking.status)")
+                            .fontWeight(.semibold)
                         HStack {
                             Button("Accept") {
                                 Task {
@@ -42,7 +55,9 @@ struct ArtistDashboardView: View {
                             .disabled(booking.status == "canceled")
                         }
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 4)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(statusColor(for: booking.status)))
                 }
             }
             .navigationTitle("My Bookings")

--- a/DashboardView.swift
+++ b/DashboardView.swift
@@ -13,6 +13,18 @@ struct DashboardView: View {
         return formatter.string(from: date)
     }
 
+    /// Maps a booking status string to a background color.
+    private func statusColor(for status: String) -> Color {
+        switch status {
+        case "accepted":
+            return Color.green.opacity(0.2)
+        case "canceled":
+            return Color.red.opacity(0.2)
+        default:
+            return Color.orange.opacity(0.2)
+        }
+    }
+
     var body: some View {
         NavigationView {
             List {
@@ -23,6 +35,7 @@ struct DashboardView: View {
                         Text("Time: \(booking.time)")
                         Text("Booked: \(formattedDate(booking.createdAt))")
                         Text("Status: \(booking.status)")
+                            .fontWeight(.semibold)
                         HStack {
                             Button("Accept") {
                                 Task {
@@ -42,7 +55,9 @@ struct DashboardView: View {
                             .disabled(booking.status == "canceled")
                         }
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 4)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(statusColor(for: booking.status)))
                 }
             }
             .navigationTitle("Dashboard")

--- a/ProfileView.swift
+++ b/ProfileView.swift
@@ -17,6 +17,18 @@ struct ProfileView: View {
         artistVM.artists.first(where: { $0.id == id })?.name ?? id
     }
 
+    /// Returns a background color representing booking status.
+    private func statusColor(for status: String) -> Color {
+        switch status {
+        case "accepted":
+            return Color.green.opacity(0.2)
+        case "canceled":
+            return Color.red.opacity(0.2)
+        default:
+            return Color.orange.opacity(0.2)
+        }
+    }
+
     var body: some View {
         VStack {
             List {
@@ -35,7 +47,12 @@ struct ProfileView: View {
                         Text("Time: \(booking.time)")
                         Text("Booked: \(formattedDate(booking.createdAt))")
                         Text("Status: \(booking.status)")
+                            .fontWeight(.semibold)
+                            .foregroundColor(.primary)
                     }
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(statusColor(for: booking.status)))
                 }
             }
 


### PR DESCRIPTION
## Summary
- show colored status indicators on ProfileView
- add colored booking rows on artist and admin dashboards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883b9a3fe0c8328ae9e34a43e251071