### PR TITLE
Refine login and register design

### DIFF
--- a/LoginView.swift
+++ b/LoginView.swift
@@ -8,36 +8,47 @@ struct LoginView: View {
     @State private var showResetAlert = false
     @State private var resetMessage = ""
 
-    // Wrapping fields in ``Form`` helps avoid Auto Layout warnings
-    // related to the keyboard's accessory view on iPad/macOS.
+    private func filterASCII(_ value: String) -> String {
+        String(value.filter { $0.isASCII })
+    }
+
     var body: some View {
-        Form {
-            Section {
-                TextField("Email", text: $email)
-                    .keyboardType(.emailAddress)
-                    .textContentType(.emailAddress)
-                    .autocapitalization(.none)
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
 
-                SecureField("Password", text: $password)
-                    .textContentType(.password)
-            }
+                Text("Welcome Back")
+                    .font(.system(size: 28, weight: .bold))
 
-            if let error = authVM.error, !error.isEmpty {
-                Section {
+                VStack(spacing: 16) {
+                    TextField("Email", text: $email)
+                        .keyboardType(.emailAddress)
+                        .textContentType(.emailAddress)
+                        .autocapitalization(.none)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: email) { email = filterASCII($0) }
+
+                    SecureField("Password", text: $password)
+                        .textContentType(.password)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: password) { password = filterASCII($0) }
+                }
+
+                if let error = authVM.error, !error.isEmpty {
                     Text(error)
                         .foregroundColor(.red)
                 }
-            }
 
-            Section {
                 Button(action: {
                     Task { await authVM.login(email: email, password: password) }
                 }) {
                     Text("Log In")
-                        .frame(maxWidth: .infinity)
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(maxWidth: .infinity, minHeight: 50)
+                        .background(Color("AccentColor"))
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(Color("AccentColor"))
                 .disabled(authVM.isLoading)
 
                 Button("Forgot Password?") {
@@ -48,24 +59,31 @@ struct LoginView: View {
                     }
                 }
                 .font(.footnote)
-                .padding(.top, -4)
 
-                Button("Register") {
-                    showRegister = true
-                }
-                .buttonStyle(.bordered)
-                .tint(Color("AccentColor"))
-                .sheet(isPresented: $showRegister) {
-                    RegisterView().environmentObject(authVM)
-                }
+                Button("Register") { showRegister = true }
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 50)
+                    .foregroundColor(Color("AccentColor"))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color("AccentColor"), lineWidth: 1)
+                    )
+                    .sheet(isPresented: $showRegister) {
+                        RegisterView().environmentObject(authVM)
+                    }
 
                 if authVM.isLoading { ProgressView() }
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 40)
+            .background(Color.white.ignoresSafeArea())
+            .alert(resetMessage, isPresented: $showResetAlert) {
+                Button("OK", role: .cancel) { }
             }
         }
-        .padding(.vertical)
-        .alert(resetMessage, isPresented: $showResetAlert) {
-            Button("OK", role: .cancel) { }
-        }
+        .navigationBarHidden(true)
     }
 }
 

--- a/RegisterView.swift
+++ b/RegisterView.swift
@@ -8,51 +8,77 @@ struct RegisterView: View {
     @State private var name = ""
     @State private var phone = ""
 
-    // ``Form`` prevents layout issues when the keyboard and its
-    // input assistant appear on screen.
-    var body: some View {
-        Form {
-            Section {
-                TextField("Name", text: $name)
-                TextField("Phone", text: $phone)
-                    .keyboardType(.phonePad)
-                TextField("Email", text: $email)
-                    .keyboardType(.emailAddress)
-                    .textContentType(.emailAddress)
-                    .autocapitalization(.none)
-                SecureField("Password (min 6 chars)", text: $password)
-                    .textContentType(.newPassword)
-                SecureField("Confirm Password", text: $confirmPassword)
-                    .textContentType(.newPassword)
-            }
+    private func filterASCII(_ value: String) -> String {
+        String(value.filter { $0.isASCII })
+    }
 
-            if let error = authVM.error, !error.isEmpty {
-                Section {
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
+
+                Text("Create Account")
+                    .font(.system(size: 28, weight: .bold))
+
+                VStack(spacing: 16) {
+                    TextField("Name", text: $name)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: name) { name = filterASCII($0) }
+
+                    TextField("Phone", text: $phone)
+                        .keyboardType(.phonePad)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: phone) { phone = String($0.filter { $0.isNumber }) }
+
+                    TextField("Email", text: $email)
+                        .keyboardType(.emailAddress)
+                        .textContentType(.emailAddress)
+                        .autocapitalization(.none)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: email) { email = filterASCII($0) }
+
+                    SecureField("Password (min 6 chars)", text: $password)
+                        .textContentType(.newPassword)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: password) { password = filterASCII($0) }
+
+                    SecureField("Confirm Password", text: $confirmPassword)
+                        .textContentType(.newPassword)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: confirmPassword) { confirmPassword = filterASCII($0) }
+                }
+
+                if let error = authVM.error, !error.isEmpty {
                     Text(error)
                         .foregroundColor(.red)
                 }
-            }
 
-            Section {
                 Button(action: {
                     Task {
                         await authVM.register(name: name, phone: phone, email: email, password: password, confirmPassword: confirmPassword)
                     }
                 }) {
                     Text("Register")
-                        .frame(maxWidth: .infinity)
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(maxWidth: .infinity, minHeight: 50)
+                        .background(Color("AccentColor"))
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(Color("AccentColor"))
                 .disabled(authVM.isLoading)
 
                 if authVM.isLoading { ProgressView() }
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 40)
+            .background(Color.white.ignoresSafeArea())
+            .onAppear {
+                UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
             }
         }
-        .padding(.vertical)
-        .onAppear {
-            UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
-        }
+        .navigationBarHidden(true)
     }
 }
 


### PR DESCRIPTION
## Summary
- redesign `LoginView` and `RegisterView` with a minimalist white background
- add ASCII-only filtering for all text fields to prevent Mongolian characters
- style buttons and text fields inspired by Apple's clean aesthetic

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6883ba25ca1883288e35665d3d1170ac