### PR TITLE
Add location tap navigation and artist profile tweaks

### DIFF
--- a/ArtistDashboardView.swift
+++ b/ArtistDashboardView.swift
@@ -38,12 +38,8 @@ struct ArtistDashboardView: View {
     var body: some View {
         NavigationView {
             List {
-                if !locationName.isEmpty {
-                    Section {
-                        Text("Location: \(locationName)")
-                            .font(.headline)
-                    }
-                }
+                // Show user's bookings first so artists immediately see their
+                // upcoming schedule when opening the dashboard.
                 ForEach(bookingVM.bookings) { booking in
                     VStack(alignment: .leading, spacing: 8) {
                         Text("User: \(booking.userId)")
@@ -74,6 +70,12 @@ struct ArtistDashboardView: View {
                     .padding(.vertical, 8)
                     .padding(.horizontal, 4)
                     .background(RoundedRectangle(cornerRadius: 8).fill(statusColor(for: booking.status)))
+                }
+                if !locationName.isEmpty {
+                    Section {
+                        Text("Location: \(locationName)")
+                            .font(.headline)
+                    }
                 }
             }
             .navigationTitle("My Bookings")

--- a/LocationSelectionView.swift
+++ b/LocationSelectionView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
+/// Location selection screen used by regular users.
+///
+/// The next step (artist selection) is now triggered directly by tapping a
+/// location row rather than pressing a separate continue button.
 struct LocationSelectionView: View {
     @EnvironmentObject private var authVM: AuthViewModel
-    @State private var selectedLocation: Location?
-    @State private var isChoosingArtist = false
-
 
     var body: some View {
         VStack(spacing: 24) {
@@ -12,55 +13,31 @@ struct LocationSelectionView: View {
                 .font(.system(size: 22, weight: .bold))
                 .padding(.top, 32)
 
+            // Each location row navigates immediately to artist selection
+            // eliminating the need for a "Үргэлжлүүлэх" button.
             ForEach(locations) { location in
-                Button(action: { selectedLocation = location }) {
+                NavigationLink(destination: ArtistSelectionView(selectedLocation: location)) {
                     HStack {
                         Text(location.name)
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(selectedLocation?.id == location.id ? .white : .primary)
+                            .foregroundColor(.primary)
                         Spacer()
-                        if selectedLocation?.id == location.id {
-                            Image(systemName: "checkmark")
-                                .foregroundColor(.white)
-                        }
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.secondary)
                     }
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(
                         RoundedRectangle(cornerRadius: 12)
-                            .fill(selectedLocation?.id == location.id ? Color("AccentColor") : Color(.systemGray6))
+                            .fill(Color(.systemGray6))
                     )
                 }
                 .buttonStyle(.plain)
             }
 
             Spacer()
-
-            Button(action: { isChoosingArtist = true }) {
-                Text("Үргэлжлүүлэх")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(maxWidth: .infinity, minHeight: 50)
-            }
-            .background(selectedLocation == nil ? Color(.systemGray4) : Color("AccentColor"))
-            .foregroundColor(.white)
-            .cornerRadius(12)
-            .disabled(selectedLocation == nil)
-            .padding(.bottom, 24)
         }
         .padding(.horizontal, 16)
-        .background(
-            NavigationLink(
-                destination: Group {
-                    if let location = selectedLocation {
-                        ArtistSelectionView(selectedLocation: location)
-                    }
-                },
-                isActive: $isChoosingArtist
-            ) {
-                EmptyView()
-            }
-            .hidden()
-        )
         .navigationTitle("Locations")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/ProfileView.swift
+++ b/ProfileView.swift
@@ -1,9 +1,22 @@
 import SwiftUI
 
+/// Profile screen shared between regular users and artists.
+///
+/// Uses the MVVM pattern by relying on ``AuthViewModel`` for authentication
+/// state and separate view models for bookings and artist data.
 struct ProfileView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @StateObject private var bookingVM = BookingViewModel()
     @StateObject private var artistVM = ArtistViewModel()
+
+    /// Returns the human readable location name for the currently
+    /// logged in artist, or `nil` when the user is not an artist.
+    private var currentLocationName: String? {
+        guard authVM.role == "artist",
+              let id = artistVM.artists.first(where: { $0.id == authVM.user?.uid })?.locationId,
+              let location = locations.first(where: { $0.id == id }) else { return nil }
+        return location.name
+    }
 
     private func formattedDate(_ timestamp: TimeInterval) -> String {
         let date = Date(timeIntervalSince1970: timestamp)
@@ -39,32 +52,41 @@ struct ProfileView: View {
                     }
                 }
 
-            Section(header: Text("Миний цагууд")) {
-                ForEach(bookingVM.bookings) { booking in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Artist: \(artistName(for: booking.artistId))")
-                        Text("Date: \(booking.date)")
-                        Text("Time: \(booking.time)")
-                        Text("Booked: \(formattedDate(booking.createdAt))")
-                        Text("Status: \(booking.status)")
-                            .fontWeight(.semibold)
-                            .foregroundColor(.primary)
+                // When the user is an artist show only their assigned location
+                if let locationName = currentLocationName {
+                    Section(header: Text("My Location")) {
+                        Text(locationName)
                     }
-                    .padding(8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(RoundedRectangle(cornerRadius: 8).fill(statusColor(for: booking.status)))
+                } else {
+                    // Regular users see their bookings instead
+                    Section(header: Text("Миний цагууд")) {
+                        ForEach(bookingVM.bookings) { booking in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Artist: \(artistName(for: booking.artistId))")
+                                Text("Date: \(booking.date)")
+                                Text("Time: \(booking.time)")
+                                Text("Booked: \(formattedDate(booking.createdAt))")
+                                Text("Status: \(booking.status)")
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.primary)
+                            }
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(statusColor(for: booking.status))
+                            )
+                        }
+                    }
+                }
+
+                Section {
+                    Button("Sign Out") { authVM.signOut() }
                 }
             }
+            .listStyle(.insetGrouped)
 
-            Section {
-                Button("Sign Out") {
-                    authVM.signOut()
-                }
-            }
-            }
-            .listStyle(InsetGroupedListStyle())
-
-            if let error = bookingVM.error {
+            if let error = bookingVM.error ?? artistVM.error {
                 Text(error)
                     .foregroundColor(.red)
             }
@@ -72,10 +94,14 @@ struct ProfileView: View {
         .navigationTitle("Profile")
         .task {
             await artistVM.fetchArtists()
-            await bookingVM.fetchBookings(userId: authVM.user?.uid)
+            if authVM.role != "artist" {
+                await bookingVM.fetchBookings(userId: authVM.user?.uid)
+            }
         }
         .refreshable {
-            await bookingVM.fetchBookings(userId: authVM.user?.uid)
+            if authVM.role != "artist" {
+                await bookingVM.fetchBookings(userId: authVM.user?.uid)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- streamline location selection to push automatically
- customize profile for artists to show current location
- display bookings first on artist dashboard

## Testing
- `swift --version`
- `swiftc /tmp/test.swift -o /tmp/test && /tmp/test`

------
https://chatgpt.com/codex/tasks/task_e_6883bfa61274832890900f8bb53b3d7e