### PR TITLE
Add per-artist schedule support

### DIFF
--- a/Artist.swift
+++ b/Artist.swift
@@ -8,4 +8,7 @@ struct Artist: Identifiable {
     let name: String
     /// Identifier of the branch/location the artist is assigned to
     let locationId: Int?
+    /// Available booking hours for the artist represented as 24h integers.
+    /// When empty all default hours are available.
+    let availableTimes: [Int]
 }

--- a/ArtistSelectionView.swift
+++ b/ArtistSelectionView.swift
@@ -50,7 +50,7 @@ struct ArtistSelectionView: View {
             .sheet(isPresented: $showBooking) {
                 if let artist = selectedArtist {
                     // Show only the next three days when booking
-                    TimeSelectionView(selectedArtist: artist.id, daysToShow: 3)
+                    TimeSelectionView(artist: artist, daysToShow: 3)
                 }
             }
             .task { await viewModel.fetchArtists() }

--- a/ArtistViewModel.swift
+++ b/ArtistViewModel.swift
@@ -18,7 +18,8 @@ final class ArtistViewModel: ObservableObject {
                 if let value = child.value as? [String: Any] {
                     let name = value["name"] as? String ?? ""
                     let locationId = value["locationId"] as? Int
-                    loaded.append(Artist(id: child.key, name: name, locationId: locationId))
+                    let times = value["availableTimes"] as? [Int] ?? []
+                    loaded.append(Artist(id: child.key, name: name, locationId: locationId, availableTimes: times))
                 }
             }
             artists = loaded
@@ -52,7 +53,8 @@ final class ArtistViewModel: ObservableObject {
                     try await db.child("users").child(userSnap.key).child("role").setValue("artist")
                     try await db.child("artists").child(userSnap.key).setValue([
                         "name": name,
-                        "locationId": NSNull()
+                        "locationId": NSNull(),
+                        "availableTimes": Array(9...18)
                     ])
                     await fetchArtists()
                     return

--- a/BranchArtistsView.swift
+++ b/BranchArtistsView.swift
@@ -43,7 +43,7 @@ struct BranchArtistsView: View {
         .sheet(isPresented: $showingTimeSelection) {
             if let artist = selectedArtist {
                 // Show only the next 3 days when booking from the admin panel
-                TimeSelectionView(selectedArtist: artist.id, daysToShow: 3)
+                TimeSelectionView(artist: artist, daysToShow: 3)
             }
         }
         .task {


### PR DESCRIPTION
## Summary
- add `availableTimes` property to `Artist`
- store default time slots for new artists
- load each artist's time slots in `ArtistViewModel`
- display time slots per artist in `TimeSelectionView`
- update artist selection views to pass the full artist object

## Testing
- `swiftc -parse *.swift`

------
https://chatgpt.com/codex/tasks/task_e_6883c210352c8328b660af8963ebc954