### PR TITLE
Improve booking visibility for artists

### DIFF
--- a/ArtistDashboardView.swift
+++ b/ArtistDashboardView.swift
@@ -86,6 +86,9 @@ struct ArtistDashboardView: View {
                 await artistVM.fetchArtists()
                 await bookingVM.fetchBookings(artistId: authVM.user?.uid)
             }
+            .refreshable {
+                await bookingVM.fetchBookings(artistId: authVM.user?.uid)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a `refreshable` modifier in `ArtistDashboardView` so artists can pull to reload new bookings

## Testing
- `swift --version`
- `swiftc -parse ArtistDashboardView.swift -o /tmp/out`


------
https://chatgpt.com/codex/tasks/task_e_6885e8775bf08328b578ee8eb364256f