### PR TITLE
Ensure bookings display per artist

### DIFF
--- a/BookingViewModel.swift
+++ b/BookingViewModel.swift
@@ -45,6 +45,15 @@ final class BookingViewModel: ObservableObject {
                 )
                 loaded.append(booking)
             }
+
+            // Filter client side as an extra safety measure in case the
+            // database query doesn't apply correctly for some reason.
+            if let artistId {
+                loaded = loaded.filter { $0.artistId == artistId }
+            } else if let userId {
+                loaded = loaded.filter { $0.userId == userId }
+            }
+
             self.bookings = loaded.sorted { $0.createdAt > $1.createdAt }
         } catch {
             // Attempt to surface a more friendly message when the

--- a/TimeSelectionViewModel.swift
+++ b/TimeSelectionViewModel.swift
@@ -40,6 +40,7 @@ final class TimeSelectionViewModel: ObservableObject {
             let hours = (snapshot.children.allObjects as? [DataSnapshot])?.compactMap { snap -> Int? in
                 guard
                     let data = snap.value as? [String: Any],
+                    data["artistId"] as? String == artistId,
                     data["status"] as? String != "canceled",
                     data["date"] as? String == date,
                     let timeString = data["time"] as? String
@@ -83,6 +84,7 @@ final class TimeSelectionViewModel: ObservableObject {
             for child in snapshot.children.allObjects as? [DataSnapshot] ?? [] {
                 guard
                     let data = child.value as? [String: Any],
+                    data["artistId"] as? String == artistId,
                     data["status"] as? String != "canceled",
                     let date = data["date"] as? String,
                     let time = data["time"] as? String,


### PR DESCRIPTION
## Summary
- restrict fetched bookings to the requested artist or user
- validate artist id when reading reserved slots
- double-check artist id when generating weekly schedule

## Testing
- `swiftc -parse BookingViewModel.swift TimeSelectionViewModel.swift`

------
https://chatgpt.com/codex/tasks/task_e_6885f1b88de083289b2fcc948f6d7b14