### PR TITLE
Improve login/register background design

### DIFF
--- a/LoginView.swift
+++ b/LoginView.swift
@@ -16,7 +16,7 @@ struct LoginView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color.brand.opacity(0.12), Color(.systemBackground)],
+            LinearGradient(colors: [Color.brand.opacity(0.12), Color.softBackground],
                            startPoint: .top, endPoint: .bottom)
                 .ignoresSafeArea()
 

--- a/RegisterView.swift
+++ b/RegisterView.swift
@@ -17,7 +17,7 @@ struct RegisterView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [Color.brand.opacity(0.12), Color(.systemBackground)],
+            LinearGradient(colors: [Color.brand.opacity(0.12), Color.softBackground],
                            startPoint: .top, endPoint: .bottom)
                 .ignoresSafeArea()
 

--- a/StyleKit.swift
+++ b/StyleKit.swift
@@ -7,6 +7,8 @@ extension Color {
     /// Primary brand color #E4897C
     static let brand = Color(red: 228/255, green: 137/255, blue: 124/255)
     static let fieldBG = Color(.systemGray6)
+    /// Soft neutral background color #F7F7F7
+    static let softBackground = Color(red: 247/255, green: 247/255, blue: 247/255)
 }
 
 // Primary filled button
@@ -50,7 +52,7 @@ struct SurfaceCard<Content: View>: View {
             content
         }
         .padding(20)
-        .background(Color.white)
+        .background(Color.softBackground)
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
         .shadow(color: .black.opacity(0.06), radius: 18, x: 0, y: 12)
         .padding(.horizontal, 16)


### PR DESCRIPTION
## Summary
- add a soft neutral background color in `StyleKit`
- use the new color for `SurfaceCard` backgrounds
- apply the updated gradient on login and register screens

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688618247e9083289a97781e58516a6b