### PR TITLE
Add booking deletion and phone info

### DIFF
--- a/ArtistDashboardView.swift
+++ b/ArtistDashboardView.swift
@@ -44,6 +44,9 @@ struct ArtistDashboardView: View {
                     ForEach(bookingVM.bookings) { booking in
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Хэрэглэгч: \(booking.userId)")
+                            if let phone = bookingVM.userPhones[booking.userId] {
+                                Text("Утас: \(phone)")
+                            }
                             Text("Огноо: \(booking.date)")
                             Text("Цаг: \(booking.time)")
                             Text("Захиалсан: \(formattedDate(booking.createdAt))")
@@ -64,6 +67,14 @@ struct ArtistDashboardView: View {
                                 }
                                 .tint(.red)
                                 .disabled(booking.status == "canceled")
+
+                                Button(role: .destructive) {
+                                    Task {
+                                        await bookingVM.deleteBooking(booking)
+                                    }
+                                } label: {
+                                    Image(systemName: "trash")
+                                }
                             }
                         }
                         .padding(.vertical, 8)

--- a/DashboardView.swift
+++ b/DashboardView.swift
@@ -31,6 +31,9 @@ struct DashboardView: View {
                 ForEach(bookingVM.bookings) { booking in
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Хэрэглэгч: \(booking.userId)")
+                        if let phone = bookingVM.userPhones[booking.userId] {
+                            Text("Утас: \(phone)")
+                        }
                         Text("Огноо: \(booking.date)")
                         Text("Цаг: \(booking.time)")
                         Text("Захиалсан: \(formattedDate(booking.createdAt))")
@@ -53,6 +56,12 @@ struct DashboardView: View {
                             }
                             .tint(.red)
                             .disabled(booking.status == "canceled")
+
+                            Button(role: .destructive) {
+                                Task { await bookingVM.deleteBooking(booking) }
+                            } label: {
+                                Image(systemName: "trash")
+                            }
                         }
                     }
                     .padding(.vertical, 8)


### PR DESCRIPTION
## Summary
- add phone lookup in `BookingViewModel`
- allow bookings to be deleted via new function
- display user's phone and delete action in artist dashboard
- show phone numbers and allow delete in admin dashboard

## Testing
- `swiftc -parse BookingViewModel.swift`
- `swiftc -parse ArtistDashboardView.swift`
- `swiftc -parse DashboardView.swift`


------
https://chatgpt.com/codex/tasks/task_e_6887281245e483288f20024ed47b1f86