### PR TITLE
Fix RegisterView login navigation

### DIFF
--- a/RegisterView.swift
+++ b/RegisterView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct RegisterView: View {
     @EnvironmentObject private var authVM: AuthViewModel
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("hasLaunchedBefore") private var hasLaunchedBefore = false
 
     @State private var name = ""
     @State private var phone = ""
@@ -88,6 +89,7 @@ struct RegisterView: View {
                             .foregroundColor(.secondary)
                         Button {
                             Haptics.tap()
+                            hasLaunchedBefore = true
                             dismiss()
                         } label: {
                             Text("Нэвтрэх").fontWeight(.semibold)


### PR DESCRIPTION
## Summary
- ensure RegisterView sets `hasLaunchedBefore` before dismissing
- allow users to navigate from registration to login screen when RegisterView is root

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68933b572e6c8328ae8faa3e91338cb6