### PR TITLE
Add iPad login UI test

### DIFF
--- a/YukiApp.swift
+++ b/YukiApp.swift
@@ -36,6 +36,11 @@ struct YukiApp: App {
             }
             .tint(Color("AccentColor"))
             .environmentObject(authVM)
+            .onAppear {
+                if ProcessInfo.processInfo.arguments.contains("--uitesting-ipad") {
+                    UIDevice.current.setValue(UIUserInterfaceIdiom.pad.rawValue, forKey: "userInterfaceIdiom")
+                }
+            }
         }
     }
 }

--- a/YukibookingappUITests/IPadLoginUITests.swift
+++ b/YukibookingappUITests/IPadLoginUITests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+final class IPadLoginUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLoginFlowOnIPad() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--uitesting-ipad")
+        app.launch()
+
+        let window = app.windows.element(boundBy: 0)
+        XCTAssertGreaterThanOrEqual(window.frame.size.width, 768, "Expected iPad width")
+
+        let emailField = app.textFields["Имэйл"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+        emailField.tap()
+        emailField.typeText("user@example.com")
+
+        let passwordField = app.secureTextFields["Нууц үг"]
+        XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
+        passwordField.tap()
+        passwordField.typeText("password123")
+
+        let loginButton = app.buttons["Нэвтрэх"]
+        XCTAssertTrue(loginButton.waitForExistence(timeout: 5))
+        loginButton.tap()
+
+        let progressIndicator = app.activityIndicators.firstMatch
+        XCTAssertTrue(progressIndicator.waitForExistence(timeout: 5))
+    }
+}


### PR DESCRIPTION
## Summary
- add UI test that launches the app as an iPad, enters credentials, taps "Нэвтрэх" and verifies a progress indicator
- allow forcing iPad interface via launch argument for UI testing

## Testing
- `swift build` (fails: Could not find Package.swift)
- `swift test` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_6897320139d0832885717b83284868a4